### PR TITLE
Fix css/js in html to use absolute reference

### DIFF
--- a/flask_profile/templates/_profile/profiler.html
+++ b/flask_profile/templates/_profile/profiler.html
@@ -1,5 +1,5 @@
 <div id="_profileContent" style="display:block;">
-  <link rel="stylesheet" href="_profile/static/css/profiler.css" type="text/css" />
+  <link rel="stylesheet" href="{{url_for('_profile.static', filename='css/profiler.css')}}" type="text/css" />
   
   <div id="_profileContentWrapper" style="display:none">
   <h1>Total: {{ total_time }}ms</h1>
@@ -39,7 +39,7 @@
     <a title="Show Profile" id="flaskShowProfileButton" href="#">&laquo;</a>
   </div>
 
-  <script type="text/javascript" src="_profile/static/js/jquery.js"></script>
-  <script type="text/javascript" src="_profile/static/js/jquery.tablesorter.js"></script>
-  <script type="text/javascript" src="_profile/static/js/profiler.js"></script>
+  <script type="text/javascript" src="{{url_for('_profile.static', filename='js/jquery.js')}}"></script>
+  <script type="text/javascript" src="{{url_for('_profile.static', filename='js/jquery.tablesorter.js')}}"></script>
+  <script type="text/javascript" src="{{url_for('_profile.static', filename='js/profiler.js')}}"></script>
 </div>


### PR DESCRIPTION
The `href` references for css/js files in `profiler.html` was written hard-coded as `_profiler/{js|css}/...`. The profiler won't load in pages which URL have more than one level (e.g., in accessing `foo.com/url_level_one/url_level_two`, the css/js files will refer to `foo.com/url_level_one/_profiler/{js|css}/...` instead of `foo.com/_profiler/{js|css}/...` which is the intended one).

The fix is made by enforcing use of `url_for` in `href` fields in `profiler.html`.
